### PR TITLE
repl: don't use ansi escape codes in prompt

### DIFF
--- a/repl.js
+++ b/repl.js
@@ -100,7 +100,7 @@ function start(){
     console.log('global error');
   });
   var cmd = repl.start({
-    prompt: ' \033[90mie › \033[39m',
+    prompt: ' › ',
     eval: function(cmd, ctx, file, fn){
       socket.emit('run', cmd, function(err, data){
         fn(err || data);


### PR DESCRIPTION
Breaks the cursor in the `readline` module in node.
See: https://github.com/joyent/node/issues/3860
