### PR TITLE
client, repl: better "error" handling

### DIFF
--- a/client.js
+++ b/client.js
@@ -7,7 +7,13 @@ socket.on('run', function(js, fn){
     var rtn = eval(js);
     fn(null, inspect(rtn, { colors: true }));
   } catch(e) {
-    fn(e.stack || e.message);
+    e.stack = e.stack;
+    e.message = e.message;
+    // String() is needed here apparently for IE6-8 which throw an error deep in
+    // socket.io that is hard to debug through SauceLabs remotely. For some
+    // reason, toString() here bypasses the bug...
+    e.name = String(e.name);
+    fn(e);
   }
 });
 


### PR DESCRIPTION
Properly catches the `SyntaxError`s in most of the browsers now.
Could probably use some improvement but this is a good start...
