### PR TITLE
client, repl: use the correct window.onerror args

### DIFF
--- a/client.js
+++ b/client.js
@@ -42,8 +42,6 @@ socket.on('run', function(js, fn){
   }
 });
 
-window.onerror = function(err){
-  if (!err) err = 'Unknown global error on `window`.';
-  if (err.stack) err = err.stack;
-  socket.emit('global err', err);
+window.onerror = function(message, url, linenumber){
+  socket.emit('global err', message, url, linenumber);
 };

--- a/repl.js
+++ b/repl.js
@@ -191,8 +191,8 @@ function start(){
     }
   });
 
-  socket.on('global err', function(err){
-    console.log('Global error: ', err);
+  socket.on('global err', function(message, url, linenumber){
+    console.log('Global error: ', message, url, linenumber);
   });
 
   socket.on('console', function(method, args){


### PR DESCRIPTION
Amazingly, the `err` Error instance is NOT passed to the `onerror` callback.
See: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers.onerror
