### PR TITLE
repl: add HTML5 doctype tag

### DIFF
--- a/repl.js
+++ b/repl.js
@@ -44,6 +44,7 @@ var app = express();
 var srv = http(app);
 app.get('/', function(req, res){
   res.send([
+    '<!DOCTYPE html>',
     '<script>options = ' + JSON.stringify(argv) + ';</script>',
     '<script src="/build.js"></script>'
   ].join('\n'));


### PR DESCRIPTION
For Standards mode compliance. Before, IE8 (and probably others) were
entering "quirks mode", which isn't a big deal in itself, but being
in standards mode seems like a better idea to me.
