### PR TITLE
Support for Android

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -23,7 +23,13 @@
     "iphone5": { "name": "iphone", "platform": "mac10.6" },
     "iphone5.1": { "name": "iphone", "platform": "mac10.6" },
     "iphone6": { "name": "iphone", "platform": "mac10.8" },
-    "iphone6.1": { "name": "iphone", "platform": "mac10.8" }
+    "iphone6.1": { "name": "iphone", "platform": "mac10.8" },
+
+    "android": { "name": "android", "platform": "linux", "version": "5" },
+    "android4.4": { "name": "android", "platform": "linux", "version": "4.4" },
+    "android4.2": { "name": "android", "platform": "linux", "version": "4.2" },
+    "android4.1": { "name": "android", "platform": "linux", "version": "4.1" }
+   
   },
   "platforms": {
     "winxp": "Windows XP",

--- a/repl.js
+++ b/repl.js
@@ -30,7 +30,7 @@ var platforms = config.platforms;
 // parse args
 if (2 == argv._.length) platform = argv._.pop();
 var str = argv._.join('');
-var parts = str.match(/([a-z]+) *(\d+\.?\d+)?/);
+var parts = str.match(/([a-z]+) *(\d+(\.\d+)?)?/);
 if (!parts) return usage();
 
 // locate browser


### PR DESCRIPTION
browser-repl is probably the greatest thing since the javascript repl.

*but*, it's been missing out on Android so far. :anguished:  This'll take care of it.

* Android entries added into the browser list
* browser version regex allows for X.Y versions, rather than just X
* explicit `deviceName` declarations for iOS & Android, to make Sauce play nice.
* the explicit `version` from the browser metadata is delivered to `wd`
* :no_entry_sign: :camera: also, I turned off `record-video` and `record-screenshots` because it seems unnecessary for browser-repl uses. But holla if you want it back.