### PR TITLE
Color prompt and updated help

### DIFF
--- a/repl.js
+++ b/repl.js
@@ -83,8 +83,9 @@ function spawn(url){
   if (version) opts.version = version;
   opts.platform = platform;
 
-  vm.init(opts, function(err){
+  vm.init(opts, function(err, m, client){
     if (err) throw err;
+    if (client) console.log('… connected to', client.browserName, client.version);
     vm.get(url, function(err){
       if (err) throw err;
 

--- a/repl.js
+++ b/repl.js
@@ -66,8 +66,8 @@ function setup(){
         return;
       }
 
-      console.log('… booting up \033[96m'
-        + browser + '\033[39m (' + (version || 'latest')
+      console.log('… booting up \u001b[96m'
+        + browser + '\u001b[39m (' + (version || 'latest')
         + ') on ' + platform);
       spawn(url);
     });
@@ -140,8 +140,10 @@ function usage(){
 
 function start(){
   console.log('… ready!');
+  var isAnsiReadlineOK = 'stripVTControlCharacters' in require('readline');
+
   var cmd = repl.start({
-    prompt: '\033[96m' + str + ' › \033[39m',
+    prompt: isAnsiReadlineOK ? '\u001b[96m' + str + ' › \u001b[39m' : str + ' › ',
     eval: function(cmd, ctx, file, fn){
       socket.emit('run', cmd, function(err, data){
         if (err) {

--- a/repl.js
+++ b/repl.js
@@ -121,10 +121,19 @@ function usage(){
   console.error(' $ repl ie6     # ie 6');
   console.error(' $ repl chrome  # chrome latest');
   console.error('');
-  console.error('browsers: ' + Object.keys(browsers).filter(function(v){
-    return !/\d/.test(v);
-  }).join(','));
-  console.error('platforms: ' + Object.keys(platforms).join(','));
+  console.error('available browsers: ');
+
+  var browsernames = {};
+  Object.keys(browsers).map(function(k){ return browsers[k] }).forEach(function(k){ browsernames[k.name] = true; });
+
+  Object.keys(browsernames).forEach(function(name){
+      console.error(
+        ' ' + name + ':   ',
+        Object.keys(browsers).filter(function(val){ return browsers[val].name == name }).join('  ')
+      );
+  });
+
+  console.error('\navailable platforms: \n  ' + Object.keys(platforms).join('  '));
   console.error('');
   process.exit(1);
 }
@@ -132,7 +141,7 @@ function usage(){
 function start(){
   console.log('… ready!');
   var cmd = repl.start({
-    prompt: str + ' › ',
+    prompt: '\033[96m' + str + ' › \033[39m',
     eval: function(cmd, ctx, file, fn){
       socket.emit('run', cmd, function(err, data){
         if (err) {


### PR DESCRIPTION
## help screen
With the addition of the new browsers, the help screen needed some love.  

Here's where I ended up: 
![image](https://cloud.githubusercontent.com/assets/39191/7440133/425adc7c-f056-11e4-83af-b433b60a2c85.png)

## color repl prompt
Also I brought back ansi escape codes to the prompt. 
I see back in https://github.com/Automattic/browser-repl/commit/d807b49c1d2ad10bfcd0aad162af19b4290e39be it was nuked, but this has since been fixed, as far as I can tell: https://github.com/joyent/node/issues/3860#issuecomment-54784252

But, I'm happy to revert this bit if you'd rather play it safe.

## action shot!
2x2 browser-repl grid of android4.1, ios 8, firefox 37, and android lollipop

![image](https://cloud.githubusercontent.com/assets/39191/7440137/64cecf66-f056-11e4-9798-a5039b73d030.png)