### PR TITLE
upgrade wd to 0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "socket.io-client": "1.3.5",
     "to-array": "0.1.4",
     "util-inspect": "0.1.8",
-    "wd": "0.2.10"
+    "wd": "0.3.11"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
While adding android support (#23) the selendroid clients were giving me problems in wd 0.2.10: 
![image](https://cloud.githubusercontent.com/assets/39191/7440153/541e40ba-f057-11e4-98b8-e55fda3e1ff2.png)

This bug has since been fixed in `wd`:
https://github.com/admc/wd/pull/308


