### PR TITLE
Fix critical minimist alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "array-map": "0.0.0",
     "express": "3.4.8",
     "foreach": "2.0.4",
-    "minimist": "0.0.7",
+    "minimist": "0.2.4",
     "ngrok": "0.1.99",
     "socket.io": "1.3.5",
     "socket.io-client": "1.3.5",


### PR DESCRIPTION
## Summary
- Bumps minimist from 0.0.7 to 0.2.4 to clear the GitHub-tracked critical manifest alert.

## Testing
- Parsed package.json and verified minimist 0.2.4
- node --check repl.js
- node --check client.js
- git diff --check

## Notes
- A temporary full npm audit still reports critical findings in the old Express, socket.io, wd, and browserify-era dependency stack. Clearing those requires a broader rebuild or archive decision, so this PR stays scoped to the direct GitHub critical alert.